### PR TITLE
Automatically add $ to main class name

### DIFF
--- a/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
@@ -85,7 +85,7 @@ object ConfigConverter {
         .withWorkdir(Paths.get(options.config.workdir).toAbsolutePath())
         .withCompilerConfig(nativeConfig)
         .withClassPath(classPath)
-        .withMainClass(main)
+        .withMainClass(main + "$")
 
       val verbosity = Tag.unwrap(options.logger.verbose)
       val logger = new FilteredLogger(verbosity)

--- a/cli/src/sbt-test/integration/cli/test
+++ b/cli/src/sbt-test/integration/cli/test
@@ -4,7 +4,7 @@
 > runCli --version
 
 # -- Link and check if outpath exists
-> runCli --outpath target/out1.exe -v -v --main Main$
+> runCli --outpath target/out1.exe -v -v --main Main
 $ exists target/out1.exe
 > runExec ./target/out1.exe
 
@@ -12,18 +12,18 @@ $ exists target/out1.exe
 -> runCli --outpath target/out2 -v -v
 
 # -- Fail to link with an incorrect option
--> runCli --outpath target/out3 -v -v --gc fast --main Main$
+-> runCli --outpath target/out3 -v -v --gc fast --main Main
 
 # -- Link even with an unspecified option
-> runCli --outpath target/out4 -v -v --unspecified --main Main$
+> runCli --outpath target/out4 -v -v --unspecified --main Main
 
 # -- Do not write nir files if not specified
-> runCli --outpath target/out5 -v -v --main Main$
+> runCli --outpath target/out5 -v -v --main Main
 -$ exists optimized.hnir
 $ exists target/out5
 
 # -- Write nir files to workdir if specified
 $ mkdir native-dir
-> runCli --outpath target/out6 -v -v --workdir native-dir --dump --main Main$
+> runCli --outpath target/out6 -v -v --workdir native-dir --dump --main Main
 $ exists native-dir/optimized.hnir
 $ exists target/out6

--- a/cli/src/sbt-test/integration/standalone/test
+++ b/cli/src/sbt-test/integration/standalone/test
@@ -1,6 +1,6 @@
 > runScript scala-native-c Main.scala
 $ exists Main$.nir
 
-> runScript scala-native-ld --main Main$ . -o scala-native-out.exe -v -v
+> runScript scala-native-ld --main Main . -o scala-native-out.exe -v -v
 $ exists scala-native-out.exe
 > runExec ./scala-native-out.exe

--- a/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
+++ b/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
@@ -16,12 +16,12 @@ import scala.scalanative.cli.options.MiscOptions
 class ConfigConverterTest extends AnyFlatSpec {
   val dummyLoggerOptions = LoggerOptions()
   val dummyNativeConfigOptions = NativeConfigOptions()
-  val dummyConfigOptions = ConfigOptions(main = Some("Main$"))
+  val dummyConfigOptions = ConfigOptions(main = Some("Main"))
   val dummyMiscOptions = MiscOptions()
 
   val dummyArguments =
     Seq("A.jar", "B.jar")
-  val dummyMain = "Main$"
+  val dummyMain = "Main"
 
   val dummyCliOptions = CliOptions(
     config = dummyConfigOptions,


### PR DESCRIPTION
Previously there was an expectation placed on the user to always put a dollar sign as main class name suffix when passing options. Now, the behavior was changed to match other scala tools.