### PR TITLE
Add option for NIR file deserialization to scala-native-p

### DIFF
--- a/cli/src/main/scala/scala/scalanative/cli/options/POptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/POptions.scala
@@ -10,9 +10,9 @@ case class POptions(
     @ValueDescription("<path>")
     classpath: List[String] = "." :: Nil,
     @HelpMessage(
-      "Instead of deserializing classes/objects, deserialize NIR files. Requires passing NIR files as arguments"
+      "Instead of passing class/object names, pass NIR file paths."
     )
-    nirFiles: Boolean = false,
+    fromPath: Boolean = false,
     @Recurse
     misc: MiscOptions
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/POptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/POptions.scala
@@ -9,6 +9,10 @@ case class POptions(
     @ExtraName("cp")
     @ValueDescription("<path>")
     classpath: List[String] = "." :: Nil,
+    @HelpMessage(
+      "Instead of deserializing classes/objects, deserialize NIR files. Requires passing NIR files as arguments"
+    )
+    nirFiles: Boolean = false,
     @Recurse
     misc: MiscOptions
 )

--- a/cli/src/sbt-test/integration/standalone/test
+++ b/cli/src/sbt-test/integration/standalone/test
@@ -9,12 +9,12 @@ $ exists Foo$.nir
 
 -> runScript scala-native-p not.existing.Class
 
-> runScript scala-native-p --nir-files Foo.nir
--> runScript scala-native-p --nir-files notExisting.nir
+> runScript scala-native-p --from-path Foo.nir
+-> runScript scala-native-p --from-path notExisting.nir
 
 > runExec jar cf inside.jar Foo.class Foo.nir Foo$.class Foo$.nir
-> runScript scala-native-p --cp inside.jar --nir-files Foo.nir Foo$.nir
--> runScript scala-native-p --cp inside.jar --nir-files Main$.nir
+> runScript scala-native-p --cp inside.jar --from-path Foo.nir Foo$.nir
+-> runScript scala-native-p --cp inside.jar --from-path Main$.nir
 
 > runScript scala-native-ld --main Main . -o scala-native-out.exe -v -v
 $ exists scala-native-out.exe

--- a/cli/src/sbt-test/integration/standalone/test
+++ b/cli/src/sbt-test/integration/standalone/test
@@ -9,6 +9,13 @@ $ exists Foo$.nir
 
 -> runScript scala-native-p not.existing.Class
 
+> runScript scala-native-p --nir-files Foo.nir
+-> runScript scala-native-p --nir-files notExisting.nir
+
+> runExec jar cf inside.jar Foo.class Foo.nir Foo$.class Foo$.nir
+> runScript scala-native-p --cp inside.jar --nir-files Foo.nir Foo$.nir
+-> runScript scala-native-p --cp inside.jar --nir-files Main$.nir
+
 > runScript scala-native-ld --main Main . -o scala-native-out.exe -v -v
 $ exists scala-native-out.exe
 > runExec ./scala-native-out.exe


### PR DESCRIPTION
This PR introduces a new option "--nir-files" to scala-native-p. It allows instead of passing classes or objects, to pass NIR files, either directly or through a classpath, which can include jar files. A simple tests were added. Some messages were also changed to better fit the two different modes.