### PR TITLE
Rename class names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val cli = project
       }
     },
     Compile / run / mainClass :=
-      Some("scala.scalanative.cli.ScalaNativeCli"),
+      Some("scala.scalanative.cli.ScalaNativeLd"),
     scalacOptions += "-Ywarn-unused:imports",
     libraryDependencies ++= Seq(
       "org.scala-native" %% "tools" % scalaNativeVersion.value,

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
@@ -4,16 +4,16 @@ import scala.scalanative.build.Build
 import scala.scalanative.util.Scope
 import scala.scalanative.cli.utils.ConfigConverter
 import scala.scalanative.cli.utils.NativeConfigParserImplicits._
-import scala.scalanative.cli.options.CliOptions
+import scala.scalanative.cli.options.LinkerOptions
 import caseapp.core.app.CaseApp
 import caseapp.core.RemainingArgs
 import scala.scalanative.cli.options.BuildInfo
 
-object ScalaNativeCli extends CaseApp[CliOptions] {
+object ScalaNativeLd extends CaseApp[LinkerOptions] {
 
   override def ignoreUnrecognized: Boolean = true
 
-  def run(options: CliOptions, args: RemainingArgs) = {
+  def run(options: LinkerOptions, args: RemainingArgs) = {
     if (options.misc.version) {
       println(BuildInfo.nativeVersion)
     } else if (options.config.main.isEmpty) {

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -16,9 +16,9 @@ import scala.scalanative.nir.Defn
 import scala.annotation.tailrec
 import java.nio.ByteBuffer
 
-object ScalaNativeP extends CaseApp[POptions] {
+object ScalaNativeP extends CaseApp[PrinterOptions] {
 
-  def run(options: POptions, args: RemainingArgs): Unit = {
+  def run(options: PrinterOptions, args: RemainingArgs): Unit = {
     if (options.misc.version) {
       println(BuildInfo.nativeVersion)
       exit(0)

--- a/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
@@ -2,10 +2,10 @@ package scala.scalanative.cli.options
 
 import caseapp._
 
-@AppName("ScalaNativeCli")
-@ProgName("scala-native-cli")
+@AppName("ScalaNativeLd")
+@ProgName("scala-native-ld")
 @ArgsName("classpath")
-case class CliOptions(
+case class LinkerOptions(
     @Recurse
     config: ConfigOptions,
     @Recurse

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -2,9 +2,10 @@ package scala.scalanative.cli.options
 
 import caseapp._
 
+@AppName("ScalaNativeP")
 @ProgName("scala-native-p")
 @ArgsName("Class names")
-case class POptions(
+case class PrinterOptions(
     @HelpMessage("Specify where to find user class files")
     @ExtraName("cp")
     @ValueDescription("<path>")

--- a/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
@@ -6,7 +6,7 @@ import scala.scalanative.build.Discover
 import java.nio.file.Paths
 import java.nio.file.Path
 import scala.util.Try
-import scala.scalanative.cli.options.CliOptions
+import scala.scalanative.cli.options.LinkerOptions
 import caseapp.Tag
 
 case class BuildOptions(
@@ -17,7 +17,7 @@ case class BuildOptions(
 object ConfigConverter {
 
   def convert(
-      options: CliOptions,
+      options: LinkerOptions,
       main: String,
       classpath: Seq[String]
   ): Either[Throwable, BuildOptions] = {
@@ -37,7 +37,7 @@ object ConfigConverter {
   }
 
   private def generateNativeConfig(
-      options: CliOptions
+      options: LinkerOptions
   ): Either[Throwable, NativeConfig] = {
 
     def toPathOrDiscover(
@@ -73,7 +73,7 @@ object ConfigConverter {
   }
 
   private def generateConfig(
-      options: CliOptions,
+      options: LinkerOptions,
       main: String,
       classPath: Seq[String]
   ): Either[Throwable, Config] = {

--- a/cli/src/patches/0.4.0/src/main/scala/scala/scalanative/cli/utils/VersionSpecificOptionsIncluder.scala
+++ b/cli/src/patches/0.4.0/src/main/scala/scala/scalanative/cli/utils/VersionSpecificOptionsIncluder.scala
@@ -2,11 +2,11 @@ package scala.scalanative.cli.utils
 
 import scala.scalanative.build.NativeConfig
 
-import scala.scalanative.cli.options.CliOptions
+import scala.scalanative.cli.options.LinkerOptions
 
 private[utils] object VersionSpecificOptionsIncluder {
   def withVersionSpecificOptions(
-      options: CliOptions,
+      options: LinkerOptions,
       nativeConfig: NativeConfig
   ): Either[Throwable, NativeConfig] = {
     Right(nativeConfig)

--- a/cli/src/patches/current/src/main/scala/scala/scalanative/cli/utils/VersionSpecificOptionsIncluder.scala
+++ b/cli/src/patches/current/src/main/scala/scala/scalanative/cli/utils/VersionSpecificOptionsIncluder.scala
@@ -2,12 +2,12 @@ package scala.scalanative.cli.utils
 
 import scala.scalanative.build.NativeConfig
 
-import _root_.scala.scalanative.cli.options.CliOptions
+import _root_.scala.scalanative.cli.options.LinkerOptions
 import scala.util.Try
 
 private[utils] object VersionSpecificOptionsIncluder {
   def withVersionSpecificOptions(
-      options: CliOptions,
+      options: LinkerOptions,
       baseNativeConfig: NativeConfig
   ): Either[Throwable, NativeConfig] = {
     generateNativeConfigWithLTP(options, baseNativeConfig).map {
@@ -15,7 +15,7 @@ private[utils] object VersionSpecificOptionsIncluder {
     }
   }
   private def generateNativeConfigWithLTP(
-      options: CliOptions,
+      options: LinkerOptions,
       baseNativeConfig: NativeConfig
   ): Either[Throwable, NativeConfig] = {
     LinktimePropertyParser

--- a/cli/src/script/scala-native-ld
+++ b/cli/src/script/scala-native-ld
@@ -13,4 +13,4 @@ for lib in $libs; do
     NATIVELIB="${NATIVELIB} $BASE/lib/${lib}_native${SCALANATIVE_BIN_VER}_$SCALA_BIN_VER-$SCALANATIVE_VER.jar"
 done
 
-scala -classpath "$CLILIB" scala.scalanative.cli.ScalaNativeCli "$@" ${NATIVELIB}
+scala -classpath "$CLILIB" scala.scalanative.cli.ScalaNativeLd "$@" ${NATIVELIB}

--- a/cli/src/script/scala-native-ld.bat
+++ b/cli/src/script/scala-native-ld.bat
@@ -12,4 +12,4 @@ set CLILIB=%BASE%\scala-native-cli-assembly_%SCALA_BIN_VER%-%SCALANATIVE_VER%.ja
 set PLUGIN=%BASE%\nscplugin_%SCALA_VER%-%SCALANATIVE_VER%.jar
 set NATIVELIB=%BASE%\nativelib%SUFFIX% %BASE%\clib%SUFFIX% %BASE%\posixlib%SUFFIX% %BASE%\windowslib%SUFFIX% %BASE%\auxlib%SUFFIX% %BASE%\javalib%SUFFIX% %BASE%\scalalib%SUFFIX%
 
-scala -classpath %CLILIB% scala.scalanative.cli.ScalaNativeCli  %* %NATIVELIB%
+scala -classpath %CLILIB% scala.scalanative.cli.ScalaNativeLd  %* %NATIVELIB%

--- a/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
+++ b/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
@@ -3,7 +3,7 @@ package scala.scalanative.cli
 import org.scalatest.flatspec.AnyFlatSpec
 import java.nio.file.Paths
 import scala.scalanative.cli.utils.ConfigConverter
-import scala.scalanative.cli.options.CliOptions
+import scala.scalanative.cli.options.LinkerOptions
 import scala.scalanative.cli.options.LoggerOptions
 import scala.scalanative.cli.options.NativeConfigOptions
 import scala.scalanative.cli.options.ConfigOptions
@@ -23,7 +23,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     Seq("A.jar", "B.jar")
   val dummyMain = "Main"
 
-  val dummyCliOptions = CliOptions(
+  val dummyCliOptions = LinkerOptions(
     config = dummyConfigOptions,
     nativeConfig = dummyNativeConfigOptions,
     logger = dummyLoggerOptions,
@@ -65,7 +65,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     def gcAssertion(gcString: String, expectedGC: GC) = {
       val parsed = for {
         gc <- NativeConfigParserImplicits.gcParser(None, gcString)
-        options = CliOptions(
+        options = LinkerOptions(
           dummyConfigOptions,
           NativeConfigOptions(gc = gc),
           dummyLoggerOptions,
@@ -86,7 +86,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     def modeAssertion(modeString: String, expectedMode: Mode) = {
       val parsed = for {
         mode <- NativeConfigParserImplicits.modeParser(None, modeString)
-        options = CliOptions(
+        options = LinkerOptions(
           dummyConfigOptions,
           NativeConfigOptions(mode = mode),
           dummyLoggerOptions,
@@ -105,7 +105,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     def ltoAssertion(ltoString: String, expectedLto: LTO) = {
       val parsed = for {
         lto <- NativeConfigParserImplicits.ltoParser(None, ltoString)
-        options = CliOptions(
+        options = LinkerOptions(
           dummyConfigOptions,
           NativeConfigOptions(lto = lto),
           dummyLoggerOptions,
@@ -129,7 +129,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     val expectedClangPath = Paths.get(clangString)
     val expectedClangPPPath = Paths.get(clangPPString)
 
-    val options = CliOptions(
+    val options = LinkerOptions(
       dummyConfigOptions,
       NativeConfigOptions(
         clang = Some(clangString),
@@ -154,7 +154,7 @@ class ConfigConverterTest extends AnyFlatSpec {
   }
 
   it should "parse boolean options as opposite of default" in {
-    val options = CliOptions(
+    val options = LinkerOptions(
       dummyConfigOptions,
       NativeConfigOptions(
         check = true,

--- a/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
+++ b/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
@@ -23,7 +23,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     Seq("A.jar", "B.jar")
   val dummyMain = "Main"
 
-  val dummyCliOptions = LinkerOptions(
+  val dummyLinkerOptions = LinkerOptions(
     config = dummyConfigOptions,
     nativeConfig = dummyNativeConfigOptions,
     logger = dummyLoggerOptions,
@@ -32,14 +32,14 @@ class ConfigConverterTest extends AnyFlatSpec {
 
   "ArgParser" should "parse default options" in {
     val config =
-      ConfigConverter.convert(dummyCliOptions, dummyMain, dummyArguments)
+      ConfigConverter.convert(dummyLinkerOptions, dummyMain, dummyArguments)
     assert(config.isRight)
   }
 
   it should "report incomplete arguments" in {
     val noArgs = Seq()
     val mainOnlyResult =
-      ConfigConverter.convert(dummyCliOptions, dummyMain, noArgs)
+      ConfigConverter.convert(dummyLinkerOptions, dummyMain, noArgs)
     assert(mainOnlyResult.left.exists(_.isInstanceOf[IllegalArgumentException]))
   }
 
@@ -56,7 +56,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     )
 
     val config =
-      ConfigConverter.convert(dummyCliOptions, dummyMain, classPathStrings)
+      ConfigConverter.convert(dummyLinkerOptions, dummyMain, classPathStrings)
 
     assert(config.exists(_.config.classPath.sameElements(expected)))
   }
@@ -167,7 +167,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     )
     val parsed = for {
       default <- ConfigConverter
-        .convert(dummyCliOptions, dummyMain, dummyArguments)
+        .convert(dummyLinkerOptions, dummyMain, dummyArguments)
         .map(_.config.compilerConfig)
       nonDefault <- ConfigConverter
         .convert(options, dummyMain, dummyArguments)


### PR DESCRIPTION
This PR introuduces some renaming in the cli: 

* `ScalaNativeCli` -> `ScalaNativeLd` (as it's only used as a linker)
* `CliOptions` -> `LinkerOptions` - to match new name the cli
* `POptions` -> `PrinterOptions` - to allign naming with the linker options

Main class in build was update to use updated class name