### PR TITLE
Allow compilation on Scala 3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,13 +7,13 @@ jobs:
       fail-fast: false
       matrix:
         OS: [ubuntu-18.04, windows-2019]
-        SN: [0.4.2]
+        scala: [2.12.15, 2.13.7, 3.1.0]
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13
       - name: Test
         run: >
-         sbt 'set cli/scalaNativeVersion := "${{matrix.SN}}"'
+         sbt 'set cli/scalaVersion := "${{matrix.scala}}"'
          +cli/test
          +cliScriptedTests/scripted
         shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,8 @@ lazy val cliPackSettings = Def.settings(
       "auxlib",
       "scalalib"
     ).map { lib =>
-      val nativeBinVersion = ScalaNativeCrossVersion.binaryVersion(snVer)
+      val nativeBinVersion =
+        ScalaNativeCrossVersion.binaryVersion(snVer.stripSuffix("-SNAPSHOT"))
       scalaNativeOrg % s"${lib}_native${nativeBinVersion}_${scalaBinVer}" % snVer
     }
     val compilerPluginModuleIDs =
@@ -138,7 +139,9 @@ lazy val cliPackSettings = Def.settings(
       val retrieveDir = s.cacheDirectory / "cli-lib-jars"
       val lm = {
         import sbt.librarymanagement.ivy._
-        val ivyConfig = InlineIvyConfiguration().withLog(log)
+        val ivyConfig = InlineIvyConfiguration()
+          .withResolvers(resolvers.value.toVector)
+          .withLog(log)
         IvyDependencyResolution(ivyConfig)
       }
       val dummyModuleName =
@@ -194,7 +197,7 @@ lazy val cliPackSettings = Def.settings(
         .replaceAllLiterally("@SCALANATIVE_VER@", snVer)
         .replaceAllLiterally(
           "@SCALANATIVE_BIN_VER@",
-          ScalaNativeCrossVersion.binaryVersion(snVer)
+          ScalaNativeCrossVersion.binaryVersion(snVer.stripSuffix("-SNAPSHOT"))
         )
       val dest = trgBin / scriptFile.getName
       IO.write(dest, processedContent)

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,15 @@
 val crossScalaVersions212 = (13 to 15).map(v => s"2.12.$v")
 val crossScalaVersions213 = (4 to 7).map(v => s"2.13.$v")
+val crossScalaVersions3 = Seq("3.1.0")
 val latestsScalaVersions =
-  Seq(crossScalaVersions212.last, crossScalaVersions213.last)
+  Seq(crossScalaVersions212, crossScalaVersions213, crossScalaVersions3).map(
+    _.last
+  )
 
 def scalaReleasesForBinaryVersion(v: String): Seq[String] = v match {
   case "2.12" => crossScalaVersions212
   case "2.13" => crossScalaVersions213
+  case "3"    => crossScalaVersions3
   case ver =>
     throw new IllegalArgumentException(
       s"Unsupported binary scala version `${ver}`"
@@ -58,7 +62,7 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "org.scala-native" %% "tools" % scalaNativeVersion.value,
       "com.github.scopt" %% "scopt" % "4.0.1",
-      "org.scalatest" %% "scalatest" % "3.1.1" % Test
+      "org.scalatest" %% "scalatest" % "3.2.10"
     ),
     buildInfoKeys := Seq[BuildInfoKey](
       "nativeVersion" -> scalaNativeVersion.value

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,6 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "org.scala-native" %% "tools" % scalaNativeVersion.value,
       "com.github.scopt" %% "scopt" % "4.0.1",
-      "com.github.alexarchambault" %% "case-app" % "2.1.0-M10",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test
     ),
     buildInfoKeys := Seq[BuildInfoKey](

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "org.scala-native" %% "tools" % scalaNativeVersion.value,
       "com.github.scopt" %% "scopt" % "4.0.1",
-      "org.scalatest" %% "scalatest" % "3.2.10"
+      "org.scalatest" %% "scalatest" % "3.2.10" % Test
     ),
     buildInfoKeys := Seq[BuildInfoKey](
       "nativeVersion" -> scalaNativeVersion.value

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val cli = project
     scalacOptions += "-Ywarn-unused:imports",
     libraryDependencies ++= Seq(
       "org.scala-native" %% "tools" % scalaNativeVersion.value,
+      "com.github.scopt" %% "scopt" % "4.0.1",
       "com.github.alexarchambault" %% "case-app" % "2.1.0-M10",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,21 @@ def scalaReleasesForBinaryVersion(v: String): Seq[String] = v match {
     )
 }
 
+def scalaStdlibForBinaryVersion(v: String): Seq[String] = {
+  val commonLibs = Seq(
+    "nativelib",
+    "clib",
+    "posixlib",
+    "windowslib",
+    "javalib",
+    "auxlib"
+  )
+  v match {
+    case "2.12" | "2.13" => commonLibs :+ "scalalib"
+    case "3"             => commonLibs :+ "scala3lib"
+  }
+}
+
 val scalaNativeVersion =
   settingKey[String]("Version of Scala Native for which to build to CLI")
 
@@ -116,16 +131,10 @@ lazy val cliPackSettings = Def.settings(
     val scalaFullVers = scalaReleasesForBinaryVersion(scalaBinVer)
     val cliAssemblyJar = assembly.value
 
+    val scalaStdLibraryModuleIDs = scalaStdlibForBinaryVersion(scalaBinVer)
+
     // Standard modules needed for linking of Scala Native
-    val stdLibModuleIDs = Seq(
-      "nativelib",
-      "clib",
-      "posixlib",
-      "windowslib",
-      "javalib",
-      "auxlib",
-      "scalalib"
-    ).map { lib =>
+    val stdLibModuleIDs = scalaStdLibraryModuleIDs.map { lib =>
       val nativeBinVersion =
         ScalaNativeCrossVersion.binaryVersion(snVer.stripSuffix("-SNAPSHOT"))
       scalaNativeOrg % s"${lib}_native${nativeBinVersion}_${scalaBinVer}" % snVer

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
@@ -11,7 +11,7 @@ import scala.scalanative.cli.options.NativeConfigOptions
 object ScalaNativeLd {
 
   def main(args: Array[String]): Unit = {
-    val parser = new scopt.OptionParser[LinkerOptions]("scala-native-p") {
+    val parser = new scopt.OptionParser[LinkerOptions]("scala-native-ld") {
       override def errorOnUnknownArgument = false
       head("scala-native-ld", BuildInfo.nativeVersion)
       arg[String]("classpath")
@@ -34,7 +34,7 @@ object ScalaNativeLd {
         )
 
       note("Help options:")
-      help("help")
+      help('h', "help")
         .text("Print this usage text and exit.")
       version("version")
         .text("Print scala-native-cli version and exit.")

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
@@ -5,22 +5,140 @@ import scala.scalanative.util.Scope
 import scala.scalanative.cli.utils.ConfigConverter
 import scala.scalanative.cli.utils.NativeConfigParserImplicits._
 import scala.scalanative.cli.options.LinkerOptions
-import caseapp.core.app.CaseApp
-import caseapp.core.RemainingArgs
 import scala.scalanative.cli.options.BuildInfo
+import scala.scalanative.build.Mode
+import scala.scalanative.build.LTO
+import scala.scalanative.build.GC
 
-object ScalaNativeLd extends CaseApp[LinkerOptions] {
+object ScalaNativeLd {
 
-  override def ignoreUnrecognized: Boolean = true
+  def main(args: Array[String]): Unit = {
+    val parser = new scopt.OptionParser[LinkerOptions]("scala-native-p") {
+      override def errorOnUnknownArgument = false
+      head("scala-native-ld", BuildInfo.nativeVersion)
+      arg[String]("classpath")
+        .hidden()
+        .optional()
+        .unbounded()
+        .action((x, c) => c.copy(classpath = c.classpath :+ x))
+      
+      note("Config options:")
+      opt[String]("main")
+        .valueName("<main>")
+        .optional()
+        .action((x, c) => c.copy(config = c.config.copy(main = Some(x))))
+        .text("Required main class.")
+      opt[String]('o', "outpath")
+        .valueName("<output-path>")
+        .optional()
+        .action((x, c) => c.copy(config = c.config.copy(outpath = x)))
+        .text("Path of the resulting output binary. [./scala-native-out]")
+      opt[String]("workdir")
+        .valueName("<path-to-directory>")
+        .optional()
+        .action((x, c) => c.copy(config = c.config.copy(workdir = x)))
+        .text("Scala Native working directory. [.]")
 
-  def run(options: LinkerOptions, args: RemainingArgs) = {
+      note("Native Config options:")
+      opt[Mode]("mode")
+        .valueName("<mode> (debug, release-fast or release-full)")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(mode = x)))
+        .text("Scala Native compilation mode. [debug]")
+      opt[LTO]("lto")
+        .valueName("<mode> (none, thin or full)")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(lto = x)))
+        .text("Link-time optimisation mode. [none]")
+      opt[GC]("gc")
+        .valueName("<gc> (immix. commix, boehm, or none)")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(gc = x)))
+        .text("Used garbage collector. [immix]")
+      opt[Unit]("link-stubs")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(linkStubs = true)))
+        .text("Should stubs be linked? [false]")
+      opt[Unit]("check")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(check = true)))
+        .text("Shall linker check that NIR is well-formed after every phase? [false]")
+      opt[Unit]("check-fatal-warnings")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(checkFatalWarnings = true)))
+        .text("Shall linker NIR check treat warnings as errors? [false]")
+      opt[Unit]("dump")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(dump = true)))
+        .text("Shall linker dump intermediate NIR after every phase? [false]")
+      opt[Unit]("no-optimize")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(noOptimize = true)))
+        .text("Should the resulting NIR code be not optimized? [false]")
+      opt[String]("ltp")
+        .valueName("<keystring=value>")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(ltp = c.nativeConfig.ltp :+ x)))
+        .text("User defined properties resolved at link-time. Multiple can be defined. Example: \"isCli=true\"")
+      opt[String]("linking-option")
+        .valueName("<passed-option>")
+        .optional()
+        .unbounded()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(linkingOption = c.nativeConfig.linkingOption :+ x)))
+        .text("Linking options passed to LLVM. Multiple can be defined.")
+      opt[String]("compile-option")
+        .valueName("<passed-option>")
+        .optional()
+        .unbounded()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(compileOption = c.nativeConfig.compileOption :+ x)))
+        .text("Compilation options passed to LLVM. Multiple can be defined.")
+      opt[String]("target-triple")
+        .valueName("<config-string>")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(targetTriple = Some(x))))
+        .text("Target triple. Defines OS, ABI and CPU architectures.")
+      opt[String]("clang")
+        .valueName("<path-to-clang>")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(clang = Some(x))))
+        .text("Path to the `clang` executable. Internally discovered if not specified.")
+      opt[String]("clang++")
+        .valueName("<path-to-clang++>")
+        .optional()
+        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(clangPP = Some(x))))
+        .text("Path to the `clang++` executable. Internally discovered if not specified.")
+      
+      note("Logger options:")
+      opt[Unit]("verbose")
+        .abbr("v")
+        .optional()
+        .unbounded()
+        .action((x, c) => c.copy(logger = c.logger.copy(verbose = c.logger.verbose + 1)))
+      
+      note("Help options:")
+      help("help")
+        .text("Print this usage text and exit.")
+      version("version")
+        .text("Print scala-native-cli version and exit.")
+    }
+
+    parser.parse(args, LinkerOptions()) match {
+      case Some(config) =>
+        runLd(config)
+      case _ =>
+        // arguments are of bad format, scopt will have displayed errors automatically
+        sys.exit(1)
+    }
+  }
+
+  def runLd(options: LinkerOptions) = {
     if (options.misc.version) {
       println(BuildInfo.nativeVersion)
     } else if (options.config.main.isEmpty) {
       println("Required option not specified: --main")
-      exit(1)
+      sys.exit(1)
     } else {
-      val (ignoredArgs, classpath) = args.all.partition(_.startsWith("-"))
+      val (ignoredArgs, classpath) = options.classpath.partition(_.startsWith("-"))
       ignoredArgs.foreach { arg =>
         println(s"Unrecognised argument: ${arg}")
       }
@@ -30,7 +148,7 @@ object ScalaNativeLd extends CaseApp[LinkerOptions] {
       buildOptionsMaybe match {
         case Left(thrown) =>
           System.err.println(thrown.getMessage())
-          exit(1)
+          sys.exit(1)
         case Right(buildOptions) =>
           Scope { implicit scope =>
             Build.build(buildOptions.config, buildOptions.outpath)

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
@@ -3,12 +3,10 @@ package scala.scalanative.cli
 import scala.scalanative.build.Build
 import scala.scalanative.util.Scope
 import scala.scalanative.cli.utils.ConfigConverter
-import scala.scalanative.cli.utils.NativeConfigParserImplicits._
 import scala.scalanative.cli.options.LinkerOptions
 import scala.scalanative.cli.options.BuildInfo
-import scala.scalanative.build.Mode
-import scala.scalanative.build.LTO
-import scala.scalanative.build.GC
+import scala.scalanative.cli.options.ConfigOptions
+import scala.scalanative.cli.options.NativeConfigOptions
 
 object ScalaNativeLd {
 
@@ -21,110 +19,32 @@ object ScalaNativeLd {
         .optional()
         .unbounded()
         .action((x, c) => c.copy(classpath = c.classpath :+ x))
-      
-      note("Config options:")
-      opt[String]("main")
-        .valueName("<main>")
-        .optional()
-        .action((x, c) => c.copy(config = c.config.copy(main = Some(x))))
-        .text("Required main class.")
-      opt[String]('o', "outpath")
-        .valueName("<output-path>")
-        .optional()
-        .action((x, c) => c.copy(config = c.config.copy(outpath = x)))
-        .text("Path of the resulting output binary. [./scala-native-out]")
-      opt[String]("workdir")
-        .valueName("<path-to-directory>")
-        .optional()
-        .action((x, c) => c.copy(config = c.config.copy(workdir = x)))
-        .text("Scala Native working directory. [.]")
 
-      note("Native Config options:")
-      opt[Mode]("mode")
-        .valueName("<mode> (debug, release-fast or release-full)")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(mode = x)))
-        .text("Scala Native compilation mode. [debug]")
-      opt[LTO]("lto")
-        .valueName("<mode> (none, thin or full)")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(lto = x)))
-        .text("Link-time optimisation mode. [none]")
-      opt[GC]("gc")
-        .valueName("<gc> (immix. commix, boehm, or none)")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(gc = x)))
-        .text("Used garbage collector. [immix]")
-      opt[Unit]("link-stubs")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(linkStubs = true)))
-        .text("Should stubs be linked? [false]")
-      opt[Unit]("check")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(check = true)))
-        .text("Shall linker check that NIR is well-formed after every phase? [false]")
-      opt[Unit]("check-fatal-warnings")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(checkFatalWarnings = true)))
-        .text("Shall linker NIR check treat warnings as errors? [false]")
-      opt[Unit]("dump")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(dump = true)))
-        .text("Shall linker dump intermediate NIR after every phase? [false]")
-      opt[Unit]("no-optimize")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(noOptimize = true)))
-        .text("Should the resulting NIR code be not optimized? [false]")
-      opt[String]("ltp")
-        .valueName("<keystring=value>")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(ltp = c.nativeConfig.ltp :+ x)))
-        .text("User defined properties resolved at link-time. Multiple can be defined. Example: \"isCli=true\"")
-      opt[String]("linking-option")
-        .valueName("<passed-option>")
-        .optional()
-        .unbounded()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(linkingOption = c.nativeConfig.linkingOption :+ x)))
-        .text("Linking options passed to LLVM. Multiple can be defined.")
-      opt[String]("compile-option")
-        .valueName("<passed-option>")
-        .optional()
-        .unbounded()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(compileOption = c.nativeConfig.compileOption :+ x)))
-        .text("Compilation options passed to LLVM. Multiple can be defined.")
-      opt[String]("target-triple")
-        .valueName("<config-string>")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(targetTriple = Some(x))))
-        .text("Target triple. Defines OS, ABI and CPU architectures.")
-      opt[String]("clang")
-        .valueName("<path-to-clang>")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(clang = Some(x))))
-        .text("Path to the `clang` executable. Internally discovered if not specified.")
-      opt[String]("clang++")
-        .valueName("<path-to-clang++>")
-        .optional()
-        .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(clangPP = Some(x))))
-        .text("Path to the `clang++` executable. Internally discovered if not specified.")
-      
+      ConfigOptions.set(this)
+      NativeConfigOptions.set(this)
+
       note("Logger options:")
       opt[Unit]("verbose")
         .abbr("v")
         .optional()
         .unbounded()
-        .action((x, c) => c.copy(logger = c.logger.copy(verbose = c.logger.verbose + 1)))
-      
+        .action((x, c) =>
+          c.copy(logger = c.logger.copy(verbose = c.logger.verbose + 1))
+        )
+        .text(
+          "Increase verbosity of internal logger. Can be specified multiple times."
+        )
+
       note("Help options:")
       help("help")
         .text("Print this usage text and exit.")
       version("version")
         .text("Print scala-native-cli version and exit.")
     }
-
     parser.parse(args, LinkerOptions()) match {
       case Some(config) =>
         runLd(config)
+        sys.exit(0)
       case _ =>
         // arguments are of bad format, scopt will have displayed errors automatically
         sys.exit(1)
@@ -138,7 +58,8 @@ object ScalaNativeLd {
       println("Required option not specified: --main")
       sys.exit(1)
     } else {
-      val (ignoredArgs, classpath) = options.classpath.partition(_.startsWith("-"))
+      val (ignoredArgs, classpath) =
+        options.classpath.partition(_.startsWith("-"))
       ignoredArgs.foreach { arg =>
         println(s"Unrecognised argument: ${arg}")
       }

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
@@ -28,9 +28,7 @@ object ScalaNativeLd {
         .abbr("v")
         .optional()
         .unbounded()
-        .action((x, c) =>
-          c.copy(logger = c.logger.copy(verbose = c.logger.verbose + 1))
-        )
+        .action((x, c) => c.copy(verbose = c.verbose + 1))
         .text(
           "Increase verbosity of internal logger. Can be specified multiple times."
         )
@@ -52,9 +50,7 @@ object ScalaNativeLd {
   }
 
   def runLd(options: LinkerOptions) = {
-    if (options.misc.version) {
-      println(BuildInfo.nativeVersion)
-    } else if (options.config.main.isEmpty) {
+    if (options.config.main.isEmpty) {
       println("Required option not specified: --main")
       sys.exit(1)
     } else {

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -33,7 +33,7 @@ object ScalaNativeP {
         .text("Print this usage text and exit.")
       version("version")
         .text("Print scala-native-cli version and exit.")
-      
+
       note("Other options:")
       PrinterOptions.set(this)
     }

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -20,29 +20,16 @@ object ScalaNativeP {
 
     val parser = new scopt.OptionParser[PrinterOptions]("scala-native-p") {
       override def errorOnUnknownArgument = false
-      
+
       head("scala-native-p", BuildInfo.nativeVersion)
       arg[String]("Class names")
         .hidden()
         .optional()
         .unbounded()
         .action((x, c) => c.copy(classNames = c.classNames :+ x))
-      opt[String]("classpath")
-        .abbr("-cp")
-        .valueName("<path>")
-        .optional()
-        .unbounded()
-        .action((x, c) => 
-          if(c.usingDefaultClassPath)
-            c.copy(classpath = x :: Nil, usingDefaultClassPath = false)
-          else 
-            c.copy(classpath = c.classpath :+ x)
-        )
-        .text("Specify where to find user class files.")
-      opt[Unit]("from-path")
-        .optional()
-        .action((x, c) => c.copy(fromPath = true))
-        .text("Instead of passing class/object names, pass NIR file paths.")
+
+      PrinterOptions.set(this)
+
       help("help")
         .text("Print this usage text and exit.")
       version("version")

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -1,7 +1,5 @@
 package scala.scalanative.cli
 
-import caseapp.core.app.CaseApp
-import caseapp.core.RemainingArgs
 import java.nio.file.Paths
 import java.io.File
 import scala.scalanative.util.Scope
@@ -16,20 +14,63 @@ import scala.scalanative.nir.Defn
 import scala.annotation.tailrec
 import java.nio.ByteBuffer
 
-object ScalaNativeP extends CaseApp[PrinterOptions] {
+object ScalaNativeP {
 
-  def run(options: PrinterOptions, args: RemainingArgs): Unit = {
-    if (options.misc.version) {
-      println(BuildInfo.nativeVersion)
-      exit(0)
+  def main(args: Array[String]): Unit = {
+
+    val parser = new scopt.OptionParser[PrinterOptions]("scala-native-p") {
+      override def errorOnUnknownArgument = false
+      
+      head("scala-native-p", BuildInfo.nativeVersion)
+      arg[String]("Class names")
+        .hidden()
+        .optional()
+        .unbounded()
+        .action((x, c) => c.copy(classNames = c.classNames :+ x))
+      opt[String]("classpath")
+        .abbr("-cp")
+        .valueName("<path>")
+        .optional()
+        .unbounded()
+        .action((x, c) => 
+          if(c.usingDefaultClassPath)
+            c.copy(classpath = x :: Nil, usingDefaultClassPath = false)
+          else 
+            c.copy(classpath = c.classpath :+ x)
+        )
+        .text("Specify where to find user class files.")
+      opt[Unit]("from-path")
+        .optional()
+        .action((x, c) => c.copy(fromPath = true))
+        .text("Instead of passing class/object names, pass NIR file paths.")
+      help("help")
+        .text("Print this usage text and exit.")
+      version("version")
+        .text("Print scala-native-cli version and exit.")
     }
 
-    if (args.all.isEmpty) {
+    parser.parse(args, PrinterOptions()) match {
+      case Some(config) =>
+        runPrinter(config)
+        sys.exit(0)
+      case _ =>
+        // arguments are of bad format, scopt will have displayed errors automatically
+        sys.exit(1)
+    }
+  }
+
+  private def runPrinter(options: PrinterOptions): Unit = {
+    if (options.misc.version) {
+      println(BuildInfo.nativeVersion)
+      sys.exit(0)
+    }
+
+    if (options.classNames.isEmpty) {
       if (options.fromPath)
         System.err.println("Required NIR file not specified.")
       else
         System.err.println("Required class/object not specified.")
-      exit(1)
+      sys.exit(1)
     }
 
     val (classpath, ignoredPaths) =
@@ -41,8 +82,8 @@ object ScalaNativeP extends CaseApp[PrinterOptions] {
       System.err.println(s"Ignoring non existing path: $path")
     }
 
-    if (options.fromPath) printFromFiles(classpath, args.all)
-    else printFromNames(classpath, args.all)
+    if (options.fromPath) printFromFiles(classpath, options.classNames)
+    else printFromNames(classpath, options.classNames)
   }
 
   private def printFromNames(
@@ -118,7 +159,7 @@ object ScalaNativeP extends CaseApp[PrinterOptions] {
 
   private def fail(msg: String): Nothing = {
     Console.err.println(msg)
-    exit(1)
+    sys.exit(1)
   }
 
 }

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -47,11 +47,6 @@ object ScalaNativeP {
   }
 
   private def runPrinter(options: PrinterOptions): Unit = {
-    if (options.misc.version) {
-      println(BuildInfo.nativeVersion)
-      sys.exit(0)
-    }
-
     if (options.classNames.isEmpty) {
       if (options.fromPath)
         System.err.println("Required NIR file not specified.")

--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -28,12 +28,14 @@ object ScalaNativeP {
         .unbounded()
         .action((x, c) => c.copy(classNames = c.classNames :+ x))
 
-      PrinterOptions.set(this)
-
-      help("help")
+      note("Help options:")
+      help('h', "help")
         .text("Print this usage text and exit.")
       version("version")
         .text("Print scala-native-cli version and exit.")
+      
+      note("Other options:")
+      PrinterOptions.set(this)
     }
 
     parser.parse(args, PrinterOptions()) match {

--- a/cli/src/main/scala/scala/scalanative/cli/options/ConfigOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/ConfigOptions.scala
@@ -1,21 +1,21 @@
 package scala.scalanative.cli.options
 
-import caseapp._
+// import caseapp._
 
 case class ConfigOptions(
-    @Group("Config")
-    @HelpMessage("Required main class.")
-    @ValueDescription("<main>")
+    // @Group("Config")
+    // @HelpMessage("Required main class.")
+    // @ValueDescription("<main>")
     main: Option[String] = None,
-    @Group("Config")
-    @ExtraName("o")
-    @HelpMessage(
-      "Path of the resulting output binary. [./scala-native-out]"
-    )
-    @ValueDescription("<output-path>")
+    // @Group("Config")
+    // @ExtraName("o")
+    // @HelpMessage(
+    //   "Path of the resulting output binary. [./scala-native-out]"
+    // )
+    // @ValueDescription("<output-path>")
     outpath: String = "scala-native-out",
-    @Group("Config")
-    @HelpMessage("Scala Native working directory. [.]")
-    @ValueDescription("<path-to-directory>")
+    // @Group("Config")
+    // @HelpMessage("Scala Native working directory. [.]")
+    // @ValueDescription("<path-to-directory>")
     workdir: String = "."
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/ConfigOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/ConfigOptions.scala
@@ -1,21 +1,33 @@
 package scala.scalanative.cli.options
 
-// import caseapp._
+import scopt.OptionParser
 
 case class ConfigOptions(
-    // @Group("Config")
-    // @HelpMessage("Required main class.")
-    // @ValueDescription("<main>")
     main: Option[String] = None,
-    // @Group("Config")
-    // @ExtraName("o")
-    // @HelpMessage(
-    //   "Path of the resulting output binary. [./scala-native-out]"
-    // )
-    // @ValueDescription("<output-path>")
     outpath: String = "scala-native-out",
-    // @Group("Config")
-    // @HelpMessage("Scala Native working directory. [.]")
-    // @ValueDescription("<path-to-directory>")
     workdir: String = "."
 )
+
+object ConfigOptions {
+  def set(parser: OptionParser[LinkerOptions]) = {
+    parser.note("Config options:")
+    parser
+      .opt[String]("main")
+      .valueName("<main>")
+      .optional()
+      .action((x, c) => c.copy(config = c.config.copy(main = Some(x))))
+      .text("Required main class.")
+    parser
+      .opt[String]('o', "outpath")
+      .valueName("<output-path>")
+      .optional()
+      .action((x, c) => c.copy(config = c.config.copy(outpath = x)))
+      .text("Path of the resulting output binary. [./scala-native-out]")
+    parser
+      .opt[String]("workdir")
+      .valueName("<path-to-directory>")
+      .optional()
+      .action((x, c) => c.copy(config = c.config.copy(workdir = x)))
+      .text("Scala Native working directory. [.]")
+  }
+}

--- a/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
@@ -1,17 +1,18 @@
 package scala.scalanative.cli.options
 
-import caseapp._
+// import caseapp._
 
-@AppName("ScalaNativeLd")
-@ProgName("scala-native-ld")
-@ArgsName("classpath")
+// @AppName("ScalaNativeLd")
+// @ProgName("scala-native-ld")
+// @ArgsName("classpath")
 case class LinkerOptions(
-    @Recurse
-    config: ConfigOptions,
-    @Recurse
-    nativeConfig: NativeConfigOptions,
-    @Recurse
-    logger: LoggerOptions,
-    @Recurse
-    misc: MiscOptions
+    classpath: List[String] = Nil,
+    // @Recurse
+    config: ConfigOptions = ConfigOptions(),
+    // @Recurse
+    nativeConfig: NativeConfigOptions = NativeConfigOptions(),
+    // @Recurse
+    logger: LoggerOptions = LoggerOptions(),
+    // @Recurse
+    misc: MiscOptions = MiscOptions()
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
@@ -1,18 +1,9 @@
 package scala.scalanative.cli.options
 
-// import caseapp._
-
-// @AppName("ScalaNativeLd")
-// @ProgName("scala-native-ld")
-// @ArgsName("classpath")
 case class LinkerOptions(
     classpath: List[String] = Nil,
-    // @Recurse
     config: ConfigOptions = ConfigOptions(),
-    // @Recurse
     nativeConfig: NativeConfigOptions = NativeConfigOptions(),
-    // @Recurse
     logger: LoggerOptions = LoggerOptions(),
-    // @Recurse
     misc: MiscOptions = MiscOptions()
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LinkerOptions.scala
@@ -4,6 +4,5 @@ case class LinkerOptions(
     classpath: List[String] = Nil,
     config: ConfigOptions = ConfigOptions(),
     nativeConfig: NativeConfigOptions = NativeConfigOptions(),
-    logger: LoggerOptions = LoggerOptions(),
-    misc: MiscOptions = MiscOptions()
+    verbose: Int = 0
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/LoggerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LoggerOptions.scala
@@ -1,12 +1,5 @@
 package scala.scalanative.cli.options
 
-// import caseapp._
-
 case class LoggerOptions(
-    // @Group("Logger")
-    // @ExtraName("v")
-    // @HelpMessage(
-    //   "Increase verbosity of internal logger. Can be specified multiple times."
-    // )
     verbose: Int = 0
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/LoggerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LoggerOptions.scala
@@ -1,12 +1,12 @@
 package scala.scalanative.cli.options
 
-import caseapp._
+// import caseapp._
 
 case class LoggerOptions(
-    @Group("Logger")
-    @ExtraName("v")
-    @HelpMessage(
-      "Increase verbosity of internal logger. Can be specified multiple times."
-    )
-    verbose: Int @@ Counter = Tag.of(0)
+    // @Group("Logger")
+    // @ExtraName("v")
+    // @HelpMessage(
+    //   "Increase verbosity of internal logger. Can be specified multiple times."
+    // )
+    verbose: Int = 0
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/LoggerOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/LoggerOptions.scala
@@ -1,5 +1,0 @@
-package scala.scalanative.cli.options
-
-case class LoggerOptions(
-    verbose: Int = 0
-)

--- a/cli/src/main/scala/scala/scalanative/cli/options/MiscOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/MiscOptions.scala
@@ -1,5 +1,0 @@
-package scala.scalanative.cli.options
-
-case class MiscOptions(
-    val version: Boolean = false
-)

--- a/cli/src/main/scala/scala/scalanative/cli/options/MiscOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/MiscOptions.scala
@@ -1,10 +1,10 @@
 package scala.scalanative.cli.options
 
-import caseapp.HelpMessage
-import caseapp.Group
+// import caseapp.HelpMessage
+// import caseapp.Group
 
 case class MiscOptions(
-    @Group("Help")
-    @HelpMessage("Print scala-native-cli version and exit")
+    // @Group("Help")
+    // @HelpMessage("Print scala-native-cli version and exit")
     val version: Boolean = false
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/MiscOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/MiscOptions.scala
@@ -1,10 +1,5 @@
 package scala.scalanative.cli.options
 
-// import caseapp.HelpMessage
-// import caseapp.Group
-
 case class MiscOptions(
-    // @Group("Help")
-    // @HelpMessage("Print scala-native-cli version and exit")
     val version: Boolean = false
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/NativeConfigOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/NativeConfigOptions.scala
@@ -133,7 +133,8 @@ object NativeConfigOptions {
         "Path to the `clang` executable. Internally discovered if not specified."
       )
     parser
-      .opt[String]("clang++")
+      .opt[String]("clang-pp")
+      .abbr("-clang++")
       .valueName("<path-to-clang++>")
       .optional()
       .action((x, c) =>

--- a/cli/src/main/scala/scala/scalanative/cli/options/NativeConfigOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/NativeConfigOptions.scala
@@ -1,71 +1,146 @@
 package scala.scalanative.cli.options
 
-// import caseapp._
+import scopt.OptionParser
+
 import scala.scalanative.build.LTO
 import scala.scalanative.build.Mode
 import scala.scalanative.build.GC
+import scala.scalanative.cli.utils.NativeConfigParserImplicits._
 
 case class NativeConfigOptions(
-    // @Group("Native Config")
-    // @HelpMessage("Scala Native compilation mode. [debug]")
-    // @ValueDescription("<mode> (debug, release-fast or release-full)")
     mode: Mode = Mode.debug,
-    // @Group("Native Config")
-    // @HelpMessage("Link-time optimisation mode. [none]")
-    // @ValueDescription("<mode> (none, thin or full)")
     lto: LTO = LTO.none,
-    // @Group("Native Config")
-    // @HelpMessage("Used garbage collector. [immix]")
-    // @ValueDescription("<gc> (immix. commix, boehm, or none)")
     gc: GC = GC.immix,
-    // @Group("Native Config")
-    // @HelpMessage("Should stubs be linked? [false]")
     linkStubs: Boolean = false,
-    // @Group("Native Config")
-    // @HelpMessage(
-    //   "Shall linker check that NIR is well-formed after every phase? [false]"
-    // )
     check: Boolean = false,
-    // @Group("Native Config")
-    // @HelpMessage("Shall linker NIR check treat warnings as errors? [false]")
     checkFatalWarnings: Boolean = false,
-    // @Group("Native Config")
-    // @HelpMessage(
-    //   "Shall linker dump intermediate NIR after every phase? [false]"
-    // )
     dump: Boolean = false,
-    // @Group("Native Config")
-    // @HelpMessage("Should the resulting NIR code be not optimized? [false]")
     noOptimize: Boolean = false,
-    // @Group("Native Config")
-    // @HelpMessage(
-    //   "User defined properties resolved at link-time. Multiple can be defined. Example: \"isCli=true\""
-    // )
-    // @ValueDescription("<keystring=value>")
     ltp: List[String] = List.empty,
-    // @Group("Native Config")
-    // @HelpMessage("Linking options passed to LLVM. Multiple can be defined.")
-    // @ValueDescription("<passed-option>")
     linkingOption: List[String] = List.empty,
-    // @Group("Native Config")
-    // @HelpMessage("Compilation options passed to LLVM. Multiple can be defined.")
-    // @ValueDescription("<passed-option>")
     compileOption: List[String] = List.empty,
-    // @Group("Native Config")
-    // @HelpMessage("Target triple. Defines OS, ABI and CPU architectures.")
-    // @ValueDescription("<config-string>")
     targetTriple: Option[String] = None,
-    // @Group("Native Config")
-    // @HelpMessage(
-    //   "Path to the `clang` executable. Internally discovered if not specified."
-    // )
-    // @ValueDescription("<path-to-clang>")
     clang: Option[String] = None,
-    // @Group("Native Config")
-    // @Name("clang++")
-    // @HelpMessage(
-    //   "Path to the `clang++` executable. Internally discovered if not specified."
-    // )
-    // @ValueDescription("<path-to-clang++>")
     clangPP: Option[String] = None
 )
+
+object NativeConfigOptions {
+  def set(parser: OptionParser[LinkerOptions]) = {
+    parser.note("Native Config options:")
+    parser
+      .opt[Mode]("mode")
+      .valueName("<mode> (debug, release-fast or release-full)")
+      .optional()
+      .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(mode = x)))
+      .text("Scala Native compilation mode. [debug]")
+    parser
+      .opt[LTO]("lto")
+      .valueName("<mode> (none, thin or full)")
+      .optional()
+      .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(lto = x)))
+      .text("Link-time optimisation mode. [none]")
+    parser
+      .opt[GC]("gc")
+      .valueName("<gc> (immix. commix, boehm, or none)")
+      .optional()
+      .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(gc = x)))
+      .text("Used garbage collector. [immix]")
+    parser
+      .opt[Unit]("link-stubs")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(linkStubs = true))
+      )
+      .text("Should stubs be linked? [false]")
+    parser
+      .opt[Unit]("check")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(check = true))
+      )
+      .text(
+        "Shall linker check that NIR is well-formed after every phase? [false]"
+      )
+    parser
+      .opt[Unit]("check-fatal-warnings")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(checkFatalWarnings = true))
+      )
+      .text("Shall linker NIR check treat warnings as errors? [false]")
+    parser
+      .opt[Unit]("dump")
+      .optional()
+      .action((x, c) => c.copy(nativeConfig = c.nativeConfig.copy(dump = true)))
+      .text("Shall linker dump intermediate NIR after every phase? [false]")
+    parser
+      .opt[Unit]("no-optimize")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(noOptimize = true))
+      )
+      .text("Should the resulting NIR code be not optimized? [false]")
+    parser
+      .opt[String]("ltp")
+      .valueName("<keystring=value>")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig =
+          c.nativeConfig.copy(ltp = c.nativeConfig.ltp :+ x)
+        )
+      )
+      .text(
+        "User defined properties resolved at link-time. Multiple can be defined. Example: \"isCli=true\""
+      )
+    parser
+      .opt[String]("linking-option")
+      .valueName("<passed-option>")
+      .optional()
+      .unbounded()
+      .action((x, c) =>
+        c.copy(nativeConfig =
+          c.nativeConfig.copy(linkingOption = c.nativeConfig.linkingOption :+ x)
+        )
+      )
+      .text("Linking options passed to LLVM. Multiple can be defined.")
+    parser
+      .opt[String]("compile-option")
+      .valueName("<passed-option>")
+      .optional()
+      .unbounded()
+      .action((x, c) =>
+        c.copy(nativeConfig =
+          c.nativeConfig.copy(compileOption = c.nativeConfig.compileOption :+ x)
+        )
+      )
+      .text("Compilation options passed to LLVM. Multiple can be defined.")
+    parser
+      .opt[String]("target-triple")
+      .valueName("<config-string>")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(targetTriple = Some(x)))
+      )
+      .text("Target triple. Defines OS, ABI and CPU architectures.")
+    parser
+      .opt[String]("clang")
+      .valueName("<path-to-clang>")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(clang = Some(x)))
+      )
+      .text(
+        "Path to the `clang` executable. Internally discovered if not specified."
+      )
+    parser
+      .opt[String]("clang++")
+      .valueName("<path-to-clang++>")
+      .optional()
+      .action((x, c) =>
+        c.copy(nativeConfig = c.nativeConfig.copy(clangPP = Some(x)))
+      )
+      .text(
+        "Path to the `clang++` executable. Internally discovered if not specified."
+      )
+  }
+}

--- a/cli/src/main/scala/scala/scalanative/cli/options/NativeConfigOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/NativeConfigOptions.scala
@@ -1,71 +1,71 @@
 package scala.scalanative.cli.options
 
-import caseapp._
+// import caseapp._
 import scala.scalanative.build.LTO
 import scala.scalanative.build.Mode
 import scala.scalanative.build.GC
 
 case class NativeConfigOptions(
-    @Group("Native Config")
-    @HelpMessage("Scala Native compilation mode. [debug]")
-    @ValueDescription("<mode> (debug, release-fast or release-full)")
+    // @Group("Native Config")
+    // @HelpMessage("Scala Native compilation mode. [debug]")
+    // @ValueDescription("<mode> (debug, release-fast or release-full)")
     mode: Mode = Mode.debug,
-    @Group("Native Config")
-    @HelpMessage("Link-time optimisation mode. [none]")
-    @ValueDescription("<mode> (none, thin or full)")
+    // @Group("Native Config")
+    // @HelpMessage("Link-time optimisation mode. [none]")
+    // @ValueDescription("<mode> (none, thin or full)")
     lto: LTO = LTO.none,
-    @Group("Native Config")
-    @HelpMessage("Used garbage collector. [immix]")
-    @ValueDescription("<gc> (immix. commix, boehm, or none)")
+    // @Group("Native Config")
+    // @HelpMessage("Used garbage collector. [immix]")
+    // @ValueDescription("<gc> (immix. commix, boehm, or none)")
     gc: GC = GC.immix,
-    @Group("Native Config")
-    @HelpMessage("Should stubs be linked? [false]")
+    // @Group("Native Config")
+    // @HelpMessage("Should stubs be linked? [false]")
     linkStubs: Boolean = false,
-    @Group("Native Config")
-    @HelpMessage(
-      "Shall linker check that NIR is well-formed after every phase? [false]"
-    )
+    // @Group("Native Config")
+    // @HelpMessage(
+    //   "Shall linker check that NIR is well-formed after every phase? [false]"
+    // )
     check: Boolean = false,
-    @Group("Native Config")
-    @HelpMessage("Shall linker NIR check treat warnings as errors? [false]")
+    // @Group("Native Config")
+    // @HelpMessage("Shall linker NIR check treat warnings as errors? [false]")
     checkFatalWarnings: Boolean = false,
-    @Group("Native Config")
-    @HelpMessage(
-      "Shall linker dump intermediate NIR after every phase? [false]"
-    )
+    // @Group("Native Config")
+    // @HelpMessage(
+    //   "Shall linker dump intermediate NIR after every phase? [false]"
+    // )
     dump: Boolean = false,
-    @Group("Native Config")
-    @HelpMessage("Should the resulting NIR code be not optimized? [false]")
+    // @Group("Native Config")
+    // @HelpMessage("Should the resulting NIR code be not optimized? [false]")
     noOptimize: Boolean = false,
-    @Group("Native Config")
-    @HelpMessage(
-      "User defined properties resolved at link-time. Multiple can be defined. Example: \"isCli=true\""
-    )
-    @ValueDescription("<keystring=value>")
+    // @Group("Native Config")
+    // @HelpMessage(
+    //   "User defined properties resolved at link-time. Multiple can be defined. Example: \"isCli=true\""
+    // )
+    // @ValueDescription("<keystring=value>")
     ltp: List[String] = List.empty,
-    @Group("Native Config")
-    @HelpMessage("Linking options passed to LLVM. Multiple can be defined.")
-    @ValueDescription("<passed-option>")
+    // @Group("Native Config")
+    // @HelpMessage("Linking options passed to LLVM. Multiple can be defined.")
+    // @ValueDescription("<passed-option>")
     linkingOption: List[String] = List.empty,
-    @Group("Native Config")
-    @HelpMessage("Compilation options passed to LLVM. Multiple can be defined.")
-    @ValueDescription("<passed-option>")
+    // @Group("Native Config")
+    // @HelpMessage("Compilation options passed to LLVM. Multiple can be defined.")
+    // @ValueDescription("<passed-option>")
     compileOption: List[String] = List.empty,
-    @Group("Native Config")
-    @HelpMessage("Target triple. Defines OS, ABI and CPU architectures.")
-    @ValueDescription("<config-string>")
+    // @Group("Native Config")
+    // @HelpMessage("Target triple. Defines OS, ABI and CPU architectures.")
+    // @ValueDescription("<config-string>")
     targetTriple: Option[String] = None,
-    @Group("Native Config")
-    @HelpMessage(
-      "Path to the `clang` executable. Internally discovered if not specified."
-    )
-    @ValueDescription("<path-to-clang>")
+    // @Group("Native Config")
+    // @HelpMessage(
+    //   "Path to the `clang` executable. Internally discovered if not specified."
+    // )
+    // @ValueDescription("<path-to-clang>")
     clang: Option[String] = None,
-    @Group("Native Config")
-    @Name("clang++")
-    @HelpMessage(
-      "Path to the `clang++` executable. Internally discovered if not specified."
-    )
-    @ValueDescription("<path-to-clang++>")
+    // @Group("Native Config")
+    // @Name("clang++")
+    // @HelpMessage(
+    //   "Path to the `clang++` executable. Internally discovered if not specified."
+    // )
+    // @ValueDescription("<path-to-clang++>")
     clangPP: Option[String] = None
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -1,19 +1,9 @@
 package scala.scalanative.cli.options
 
-import caseapp._
-
-@AppName("ScalaNativeP")
-@ProgName("scala-native-p")
-@ArgsName("Class names")
 case class PrinterOptions(
-    @HelpMessage("Specify where to find user class files")
-    @ExtraName("cp")
-    @ValueDescription("<path>")
+    classNames: List[String] = Nil,
     classpath: List[String] = "." :: Nil,
-    @HelpMessage(
-      "Instead of passing class/object names, pass NIR file paths."
-    )
+    usingDefaultClassPath: Boolean = true,
     fromPath: Boolean = false,
-    @Recurse
-    misc: MiscOptions
+    misc: MiscOptions = MiscOptions()
 )

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -1,5 +1,7 @@
 package scala.scalanative.cli.options
 
+import scopt.OptionParser
+
 case class PrinterOptions(
     classNames: List[String] = Nil,
     classpath: List[String] = "." :: Nil,
@@ -7,3 +9,26 @@ case class PrinterOptions(
     fromPath: Boolean = false,
     misc: MiscOptions = MiscOptions()
 )
+
+object PrinterOptions {
+  def set(parser: OptionParser[PrinterOptions]) = {
+    parser
+      .opt[String]("classpath")
+      .abbr("-cp")
+      .valueName("<path>")
+      .optional()
+      .unbounded()
+      .action((x, c) =>
+        if (c.usingDefaultClassPath)
+          c.copy(classpath = x :: Nil, usingDefaultClassPath = false)
+        else
+          c.copy(classpath = c.classpath :+ x)
+      )
+      .text("Specify where to find user class files.")
+    parser
+      .opt[Unit]("from-path")
+      .optional()
+      .action((x, c) => c.copy(fromPath = true))
+      .text("Instead of passing class/object names, pass NIR file paths.")
+  }
+}

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -6,8 +6,7 @@ case class PrinterOptions(
     classNames: List[String] = Nil,
     classpath: List[String] = "." :: Nil,
     usingDefaultClassPath: Boolean = true,
-    fromPath: Boolean = false,
-    misc: MiscOptions = MiscOptions()
+    fromPath: Boolean = false
 )
 
 object PrinterOptions {

--- a/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
@@ -7,7 +7,6 @@ import java.nio.file.Paths
 import java.nio.file.Path
 import scala.util.Try
 import scala.scalanative.cli.options.LinkerOptions
-import caseapp.Tag
 
 case class BuildOptions(
     config: Config,
@@ -85,7 +84,7 @@ object ConfigConverter {
         .withClassPath(classPath)
         .withMainClass(main + "$")
 
-      val verbosity = Tag.unwrap(options.logger.verbose)
+      val verbosity = options.logger.verbose
       val logger = new FilteredLogger(verbosity)
       config.withLogger(logger)
     }

--- a/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
@@ -84,7 +84,7 @@ object ConfigConverter {
         .withClassPath(classPath)
         .withMainClass(main + "$")
 
-      val verbosity = options.logger.verbose
+      val verbosity = options.verbose
       val logger = new FilteredLogger(verbosity)
       config.withLogger(logger)
     }

--- a/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/ConfigConverter.scala
@@ -82,7 +82,7 @@ object ConfigConverter {
         .withWorkdir(Paths.get(options.config.workdir).toAbsolutePath())
         .withCompilerConfig(nativeConfig)
         .withClassPath(classPath)
-        .withMainClass(main + "$")
+        .withMainClass(main)
 
       val verbosity = options.verbose
       val logger = new FilteredLogger(verbosity)

--- a/cli/src/main/scala/scala/scalanative/cli/utils/NativeConfigParserImplicits.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/NativeConfigParserImplicits.scala
@@ -4,42 +4,30 @@ import scala.scalanative.build.LTO
 import scala.scalanative.build.GC
 import scala.scalanative.build.Mode
 
-import caseapp.core.argparser.SimpleArgParser
-import caseapp.core.argparser.ArgParser
-
 object NativeConfigParserImplicits {
 
-  implicit val ltoParser: ArgParser[LTO] =
-    SimpleArgParser.from[LTO]("lto") {
-      case "none" => Right(LTO.none)
-      case "thin" => Right(LTO.thin)
-      case "full" => Right(LTO.full)
-      case other =>
-        Left(
-          caseapp.core.Error.UnrecognizedArgument(other)
-        )
+  implicit val ltoRead: scopt.Read[LTO] =
+    scopt.Read.reads{
+      case "none" => LTO.none
+      case "thin" => LTO.thin
+      case "full" => LTO.full
+      case other => throw new IllegalArgumentException(other)
     }
 
-  implicit val gcParser: ArgParser[GC] =
-    SimpleArgParser.from[GC]("gc") {
-      case "immix"  => Right(GC.immix)
-      case "commix" => Right(GC.commix)
-      case "boehm"  => Right(GC.boehm)
-      case "none"   => Right(GC.none)
-      case other =>
-        Left(
-          caseapp.core.Error.UnrecognizedArgument(other)
-        )
+  implicit val gcRead: scopt.Read[GC] =
+    scopt.Read.reads {
+      case "immix"  => GC.immix
+      case "commix" => GC.commix
+      case "boehm"  => GC.boehm
+      case "none"   => GC.none
+      case other => throw new IllegalArgumentException(other)
     }
 
-  implicit val modeParser: ArgParser[Mode] =
-    SimpleArgParser.from[Mode]("mode") {
-      case "debug"        => Right(Mode.debug)
-      case "release-fast" => Right(Mode.releaseFast)
-      case "release-full" => Right(Mode.releaseFull)
-      case other =>
-        Left(
-          caseapp.core.Error.UnrecognizedArgument(other)
-        )
+  implicit val modeRead: scopt.Read[Mode] =
+    scopt.Read.reads {
+      case "debug"        => Mode.debug
+      case "release-fast" => Mode.releaseFast
+      case "release-full" => Mode.releaseFull
+      case other => throw new IllegalArgumentException(other)
     }
 }

--- a/cli/src/main/scala/scala/scalanative/cli/utils/NativeConfigParserImplicits.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/NativeConfigParserImplicits.scala
@@ -7,11 +7,11 @@ import scala.scalanative.build.Mode
 object NativeConfigParserImplicits {
 
   implicit val ltoRead: scopt.Read[LTO] =
-    scopt.Read.reads{
+    scopt.Read.reads {
       case "none" => LTO.none
       case "thin" => LTO.thin
       case "full" => LTO.full
-      case other => throw new IllegalArgumentException(other)
+      case other  => throw new IllegalArgumentException(other)
     }
 
   implicit val gcRead: scopt.Read[GC] =
@@ -20,7 +20,7 @@ object NativeConfigParserImplicits {
       case "commix" => GC.commix
       case "boehm"  => GC.boehm
       case "none"   => GC.none
-      case other => throw new IllegalArgumentException(other)
+      case other    => throw new IllegalArgumentException(other)
     }
 
   implicit val modeRead: scopt.Read[Mode] =
@@ -28,6 +28,6 @@ object NativeConfigParserImplicits {
       case "debug"        => Mode.debug
       case "release-fast" => Mode.releaseFast
       case "release-full" => Mode.releaseFull
-      case other => throw new IllegalArgumentException(other)
+      case other          => throw new IllegalArgumentException(other)
     }
 }

--- a/cli/src/sbt-test/integration/cli/build.sbt
+++ b/cli/src/sbt-test/integration/cli/build.sbt
@@ -1,3 +1,4 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
 enablePlugins(ScalaNativePlugin)
 
 import sbt._

--- a/cli/src/sbt-test/integration/cli/project/build.sbt
+++ b/cli/src/sbt-test/integration/cli/project/build.sbt
@@ -1,11 +1,11 @@
-{
-  val pluginVersion = System.getProperty("plugin.version")
-  if (pluginVersion == null)
-    throw new RuntimeException(
-      """|The system property 'plugin.version' is not defined.
-         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
-    )
-  else {
-    addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
-  }
+resolvers += Resolver.sonatypeRepo("snapshots")
+
+val pluginVersion = System.getProperty("plugin.version")
+if (pluginVersion == null)
+  throw new RuntimeException(
+    """|The system property 'plugin.version' is not defined.
+        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+  )
+else {
+  addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
 }

--- a/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
+++ b/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
@@ -63,16 +63,16 @@ class ConfigConverterTest extends AnyFlatSpec {
 
   it should "handle NativeConfig GC correctly" in {
     def gcAssertion(gcString: String, expectedGC: GC) = {
-      val parsed = for {
-        gc <- NativeConfigParserImplicits.gcParser(None, gcString)
-        options = LinkerOptions(
+      val gc = NativeConfigParserImplicits.gcRead.reads(gcString)
+      val options = LinkerOptions(
+          dummyArguments.toList,
           dummyConfigOptions,
           NativeConfigOptions(gc = gc),
           dummyLoggerOptions,
           dummyMiscOptions
         )
-        converted <- ConfigConverter
-          .convert(options, dummyMain, dummyArguments)
+      val parsed = for {
+        converted <- ConfigConverter.convert(options, dummyMain, dummyArguments)
       } yield converted.config.gc
       assert(parsed.contains(expectedGC))
     }
@@ -84,14 +84,15 @@ class ConfigConverterTest extends AnyFlatSpec {
 
   it should "handle NativeConfig Mode correctly" in {
     def modeAssertion(modeString: String, expectedMode: Mode) = {
-      val parsed = for {
-        mode <- NativeConfigParserImplicits.modeParser(None, modeString)
-        options = LinkerOptions(
+      val mode = NativeConfigParserImplicits.modeRead.reads(modeString)
+      val options = LinkerOptions(
+          dummyArguments.toList,
           dummyConfigOptions,
           NativeConfigOptions(mode = mode),
           dummyLoggerOptions,
           dummyMiscOptions
         )
+      val parsed = for {
         converted <- ConfigConverter.convert(options, dummyMain, dummyArguments)
       } yield converted.config.compilerConfig.mode
       assert(parsed.contains(expectedMode))
@@ -103,14 +104,15 @@ class ConfigConverterTest extends AnyFlatSpec {
 
   it should "handle NativeConfig LTO correctly" in {
     def ltoAssertion(ltoString: String, expectedLto: LTO) = {
-      val parsed = for {
-        lto <- NativeConfigParserImplicits.ltoParser(None, ltoString)
-        options = LinkerOptions(
+      val lto = NativeConfigParserImplicits.ltoRead.reads(ltoString)
+      val options = LinkerOptions(
+          dummyArguments.toList,
           dummyConfigOptions,
           NativeConfigOptions(lto = lto),
           dummyLoggerOptions,
           dummyMiscOptions
         )
+      val parsed = for {
         opts <- ConfigConverter
           .convert(options, dummyMain, dummyArguments)
       } yield opts.config.compilerConfig.lto
@@ -130,6 +132,7 @@ class ConfigConverterTest extends AnyFlatSpec {
     val expectedClangPPPath = Paths.get(clangPPString)
 
     val options = LinkerOptions(
+      dummyArguments.toList,
       dummyConfigOptions,
       NativeConfigOptions(
         clang = Some(clangString),
@@ -155,6 +158,7 @@ class ConfigConverterTest extends AnyFlatSpec {
 
   it should "parse boolean options as opposite of default" in {
     val options = LinkerOptions(
+      classpath = dummyArguments.toList,
       dummyConfigOptions,
       NativeConfigOptions(
         check = true,

--- a/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
+++ b/cli/src/test/scala/scala/scalanative/cli/utils/ConfigConverterTest.scala
@@ -151,7 +151,8 @@ class ConfigConverterTest extends AnyFlatSpec {
         check = true,
         dump = true,
         noOptimize = true,
-        linkStubs = true
+        linkStubs = true,
+        checkFatalWarnings = true
       )
     )
     val parsed = for {
@@ -170,6 +171,7 @@ class ConfigConverterTest extends AnyFlatSpec {
         assert(nonDefault.dump != default.dump)
         assert(nonDefault.optimize != default.optimize)
         assert(nonDefault.linkStubs != default.linkStubs)
+        assert(nonDefault.checkFatalWarnings != default.checkFatalWarnings)
       }
     )
   }


### PR DESCRIPTION
To achieve this, several changes were introduced:
* case-app dependency was replaced with scopt, which natively supports Scala 3. The scopt parsing was made to be compatible with the previous scala-native-cli version i.e. no option was renamed. An effort was made to group options like it was done in case-app. Of course, the help message is not identical, similarly sometimes a different phrasing is used when there is a parsing error - the exit codes used should be the exact same though.
* scalatest version was updated to one natively supporting Scala 3
* native version was updated to 0.4.3-SNAPSHOT resolved from Sonatype repository. This introduces additions of new resolvers in several places
* CI tests were changed - now instead of testing on different Scala Native versions it is being tested against different Scala versions
* Some tests were simplified to match the changes with scopt (the contents were not changed, just the used abstractions were simplified)