### PR TITLE
Add verbose option

### DIFF
--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeP.scala
@@ -4,13 +4,12 @@ import java.nio.file.Paths
 import java.io.File
 import scala.scalanative.util.Scope
 import scala.scalanative.cli.options._
-import scala.scalanative.nir.Global
+import scala.scalanative.nir._
 import scala.scalanative.build.Config
 import scala.scalanative.linker.ClassLoader
 import java.nio.file.Path
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir.serialization.deserializeBinary
-import scala.scalanative.nir.Defn
 import scala.annotation.tailrec
 import java.nio.ByteBuffer
 
@@ -66,13 +65,13 @@ object ScalaNativeP {
       System.err.println(s"Ignoring non existing path: $path")
     }
 
-    if (options.fromPath) printFromFiles(classpath, options.classNames)
-    else printFromNames(classpath, options.classNames)
+    if (options.fromPath) printFromFiles(classpath, options)
+    else printFromNames(classpath, options)
   }
 
   private def printFromNames(
       classpath: List[Path],
-      args: Seq[String]
+      options: PrinterOptions
   ): Unit = {
     Scope { implicit scope =>
       val classLoader =
@@ -81,10 +80,10 @@ object ScalaNativeP {
         }
 
       for {
-        className <- args
+        className <- options.classNames
       } {
         classLoader.load(Global.Top(className)) match {
-          case Some(defns) => printNIR(defns)
+          case Some(defns) => printNIR(defns, options.verbose)
           case None => fail(s"Not found class/object with name `${className}`")
         }
       }
@@ -93,7 +92,7 @@ object ScalaNativeP {
 
   private def printFromFiles(
       classpath: List[Path],
-      args: Seq[String]
+      options: PrinterOptions
   ): Unit = {
 
     Scope { implicit scope =>
@@ -122,19 +121,24 @@ object ScalaNativeP {
         }
       }
       for {
-        fileName <- args
+        fileName <- options.classNames
         path = Paths.get(fileName).normalize()
         content <- findAndRead(cp, path)
           .orElse(fail(s"Not found file with name `${fileName}`"))
       } {
         val defns = deserializeBinary(content, fileName)
-        printNIR(defns)
+        printNIR(defns, options.verbose)
       }
     }
   }
 
-  private def printNIR(defns: Seq[Defn]) =
+  private def printNIR(defns: Seq[Defn], verbose: Boolean) =
     defns
+      .map {
+        case defn @ Defn.Define(attrs, name, ty, _) if !verbose =>
+          Defn.Declare(attrs, name, ty)(defn.pos)
+        case defn => defn
+      }
       .sortBy(_.name.mangle)
       .foreach { d =>
         println(d.show)

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -34,7 +34,6 @@ object PrinterOptions {
       .opt[Unit]("verbose")
       .abbr("-v")
       .optional()
-      .unbounded()
       .action((_, c) => c.copy(verbose = true))
       .text("Print all informations about NIR, including method definitions.")
 

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -6,7 +6,8 @@ case class PrinterOptions(
     classNames: List[String] = Nil,
     classpath: List[String] = "." :: Nil,
     usingDefaultClassPath: Boolean = true,
-    fromPath: Boolean = false
+    fromPath: Boolean = false,
+    verbose: Boolean = false
 )
 
 object PrinterOptions {
@@ -29,5 +30,13 @@ object PrinterOptions {
       .optional()
       .action((x, c) => c.copy(fromPath = true))
       .text("Instead of passing class/object names, pass NIR file paths.")
+    parser
+      .opt[Unit]("verbose")
+      .abbr("-v")
+      .optional()
+      .unbounded()
+      .action((_, c) => c.copy(verbose = true))
+      .text("Print all informations about NIR, including method definitions.")
+
   }
 }

--- a/cli/src/sbt-test/integration/standalone/test
+++ b/cli/src/sbt-test/integration/standalone/test
@@ -10,6 +10,9 @@ $ exists Foo$.nir
 -> runScript scala-native-p not.existing.Class
 
 > runScript scala-native-p --from-path Foo.nir
+> runScript scala-native-p --from-path -v Foo.nir
+> runScript scala-native-p --from-path --verbose Foo.nir
+
 -> runScript scala-native-p --from-path notExisting.nir
 
 > runExec jar cf inside.jar Foo.class Foo.nir Foo$.class Foo$.nir


### PR DESCRIPTION
This PR adds a `verbose` setting similar to the behaviour of `scalap --verbose`. Now `scala-native-p` by default prints only signatures of methods and classes. When `verbose` flag is passed implementation of methods would be shown additionally.  