### PR TITLE
Fix minors bugs and fix support for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,8 @@ inThisBuild(
           Some("scm:git:git@github.com:scala-native/scala-native-cli.git")
       )
     ),
-    resolvers += Resolver.sonatypeRepo("snapshots")
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+    resolvers += Resolver.mavenCentral
   )
 )
 val cliPackLibJars =

--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,11 @@ lazy val cliScriptedTests = project
     }
   )
 
+def nativeBinaryVersion(version: String): String = {
+  val VersionPattern = raw"(\d+)\.(\d+)\.(\d+)(\-.*)?".r
+  val VersionPattern(major, minor, _, _) = version
+  s"$major.$minor"
+}
 lazy val cliPackSettings = Def.settings(
   cliPackLibJars := {
     val s = streams.value
@@ -142,8 +147,7 @@ lazy val cliPackSettings = Def.settings(
     val scalaNativeOrg = organization.value
     val scalaBinVer = scalaBinaryVersion.value
     val snVer = scalaNativeVersion.value
-    val nativeBinVer =
-      ScalaNativeCrossVersion.binaryVersion(snVer.stripSuffix("-SNAPSHOT"))
+    val nativeBinVer = nativeBinaryVersion(snVer)
 
     val scalaFullVers = scalaReleasesForBinaryVersion(scalaBinVer)
     val cliAssemblyJar = assembly.value
@@ -222,7 +226,7 @@ lazy val cliPackSettings = Def.settings(
         .replaceAllLiterally("@SCALANATIVE_VER@", snVer)
         .replaceAllLiterally(
           "@SCALANATIVE_BIN_VER@",
-          ScalaNativeCrossVersion.binaryVersion(snVer.stripSuffix("-SNAPSHOT"))
+          nativeBinaryVersion(snVer)
         )
       val dest = trgBin / scriptFile.getName
       IO.write(dest, processedContent)

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -14,7 +14,7 @@ object PrinterOptions {
   def set(parser: OptionParser[PrinterOptions]) = {
     parser
       .opt[String]("classpath")
-      .abbr("cp")
+      .abbr("-cp")
       .valueName("<path>")
       .optional()
       .unbounded()

--- a/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/options/PrinterOptions.scala
@@ -14,7 +14,7 @@ object PrinterOptions {
   def set(parser: OptionParser[PrinterOptions]) = {
     parser
       .opt[String]("classpath")
-      .abbr("-cp")
+      .abbr("cp")
       .valueName("<path>")
       .optional()
       .unbounded()
@@ -32,7 +32,7 @@ object PrinterOptions {
       .text("Instead of passing class/object names, pass NIR file paths.")
     parser
       .opt[Unit]("verbose")
-      .abbr("-v")
+      .abbr("v")
       .optional()
       .action((_, c) => c.copy(verbose = true))
       .text("Print all informations about NIR, including method definitions.")

--- a/cli/src/sbt-test/integration/standalone/build.sbt
+++ b/cli/src/sbt-test/integration/standalone/build.sbt
@@ -34,7 +34,10 @@ runScript := {
   val ver = scalaVersion.value
   val cacheDir =
     new File(cliPackDir).getParentFile.getParentFile / s"fetchScala-$ver"
-  val scalaBinDir = cacheDir / s"scala-$ver" / "bin"
+  val scalaDir =
+    if (ver.startsWith("3.")) s"scala3-$ver"
+    else s"scala-$ver"
+  val scalaBinDir = cacheDir / scalaDir / "bin"
 
   FileFunction.cached(
     cacheDir / s"fetchScala-$ver",
@@ -42,10 +45,12 @@ runScript := {
     FilesInfo.exists
   ) { _ =>
     if (!scalaBinDir.exists) {
-      IO.unzipURL(
-        url(s"https://downloads.lightbend.com/scala/${ver}/scala-$ver.zip"),
-        cacheDir
-      )
+      val downloadUrl =
+        if (ver.startsWith("3."))
+          s"https://github.com/lampepfl/dotty/releases/download/$ver/$scalaDir.zip"
+        else
+          s"https://downloads.lightbend.com/scala/${ver}/$scalaDir.zip"
+      IO.unzipURL(url(downloadUrl), cacheDir)
     }
     // Make sure we can execute scala/scalac from downloaded distro
     scalaBinDir

--- a/cli/src/sbt-test/integration/standalone/test
+++ b/cli/src/sbt-test/integration/standalone/test
@@ -4,8 +4,8 @@ $ exists Foo.nir
 $ exists Foo$.nir 
 
 > runScript scala-native-p Main$ Foo Foo$
-> runScript scala-native-p Main$ --cp . --classpath target --cp IgnoredNotExistingDir
-> runScript scala-native-p --cp @NATIVE_LIB@ java.lang.Runnable
+> runScript scala-native-p Main$ -cp . --classpath target -cp IgnoredNotExistingDir
+> runScript scala-native-p -cp @NATIVE_LIB@ java.lang.Runnable
 
 -> runScript scala-native-p not.existing.Class
 
@@ -22,8 +22,8 @@ $ exists  ../scala-native-test/Foo2.nir
 > runScript scala-native-p --from-path ../scala-native-test/Foo2.nir
 
 > runExec jar cf inside.jar Foo.class Foo.nir Foo$.class Foo$.nir
-> runScript scala-native-p --cp inside.jar --from-path Foo.nir Foo$.nir
--> runScript scala-native-p --cp inside.jar --from-path Main$.nir
+> runScript scala-native-p -cp inside.jar --from-path Foo.nir Foo$.nir
+-> runScript scala-native-p -cp inside.jar --from-path Main$.nir
 
 > runScript scala-native-ld --main Main . -o scala-native-out.exe -v -v
 $ exists scala-native-out.exe

--- a/cli/src/sbt-test/integration/standalone/test
+++ b/cli/src/sbt-test/integration/standalone/test
@@ -4,8 +4,8 @@ $ exists Foo.nir
 $ exists Foo$.nir 
 
 > runScript scala-native-p Main$ Foo Foo$
-> runScript scala-native-p Main$ -cp . --classpath target -cp IgnoredNotExistingDir
-> runScript scala-native-p -cp @NATIVE_LIB@ java.lang.Runnable
+> runScript scala-native-p Main$ --cp . --classpath target --cp IgnoredNotExistingDir
+> runScript scala-native-p --cp @NATIVE_LIB@ java.lang.Runnable
 
 -> runScript scala-native-p not.existing.Class
 
@@ -22,8 +22,8 @@ $ exists  ../scala-native-test/Foo2.nir
 > runScript scala-native-p --from-path ../scala-native-test/Foo2.nir
 
 > runExec jar cf inside.jar Foo.class Foo.nir Foo$.class Foo$.nir
-> runScript scala-native-p -cp inside.jar --from-path Foo.nir Foo$.nir
--> runScript scala-native-p -cp inside.jar --from-path Main$.nir
+> runScript scala-native-p --cp inside.jar --from-path Foo.nir Foo$.nir
+-> runScript scala-native-p --cp inside.jar --from-path Main$.nir
 
 > runScript scala-native-ld --main Main . -o scala-native-out.exe -v -v
 $ exists scala-native-out.exe

--- a/cli/src/script/scala-native-c
+++ b/cli/src/script/scala-native-c
@@ -5,16 +5,18 @@ SCALANATIVE_VER="@SCALANATIVE_VER@"
 SCALANATIVE_BIN_VER="@SCALANATIVE_BIN_VER@"
 SCALA_VER=$(scalac -version 2>&1 | grep -i scala | grep -o '[0-9]\.[0-9]\+\.[0-9]\+')
 
-if [ "$(echo $SCALA_VER | cut -d '.' -f 1-2)" != "$SCALA_BIN_VER" ]; then
+if [ "$SCALA_BIN_VER" != "3" ] && [ "$(echo $SCALA_VER | cut -d '.' -f 1-2)" != "$SCALA_BIN_VER" ]; then
     echo "This bundle of Scala Native CLI is for $SCALA_BIN_VER. Your scala version is $SCALA_VER!" >&2
     exit 1
 fi
-
 
 BASE="$(dirname $0)/.."
 PLUGIN="$BASE/lib/nscplugin_$SCALA_VER-$SCALANATIVE_VER.jar"
 NATIVELIB=""
 libs="nativelib clib posixlib windowslib auxlib javalib scalalib"
+if [ "$SCALA_BIN_VER" = "3" ]; then
+    libs="$libs scala3lib"
+fi
 for lib in $libs; do
     NATIVELIB="${NATIVELIB}:$BASE/lib/${lib}_native${SCALANATIVE_BIN_VER}_$SCALA_BIN_VER-$SCALANATIVE_VER.jar"
 done

--- a/cli/src/script/scala-native-c.bat
+++ b/cli/src/script/scala-native-c.bat
@@ -7,9 +7,11 @@ set SCALANATIVE_BIN_VER=@SCALANATIVE_BIN_VER@
 
 for /F "tokens=5" %%i in (' scala -version 2^>^&1 1^>nul ') do set SCALA_VER=%%i
 
-if NOT "%SCALA_VER:~0,4%" == "%SCALA_BIN_VER%" (
-  echo "This bundle of Scala Native CLI is for %SCALA_BIN_VER%. Your scala version is %SCALA_VER%!" 1>&2
-  EXIT 1
+if NOT "%SCALA_BIN_VER%" == "3" (
+  if NOT "%SCALA_VER:~0,4%" == "%SCALA_BIN_VER%" (
+    echo "This bundle of Scala Native CLI is for %SCALA_BIN_VER%. Your scala version is %SCALA_VER%!" 1>&2
+    EXIT 1
+  )
 )
 
 set BASE=%~dp0\..\lib
@@ -17,5 +19,7 @@ set SUFFIX=_native%SCALANATIVE_BIN_VER%_%SCALA_BIN_VER%-%SCALANATIVE_VER%.jar
 
 set PLUGIN=%BASE%\nscplugin_%SCALA_VER%-%SCALANATIVE_VER%.jar
 set NATIVELIB=%BASE%\nativelib%SUFFIX%;%BASE%\clib%SUFFIX%;%BASE%\posixlib%SUFFIX%;%BASE%\windowslib%SUFFIX%;%BASE%\auxlib%SUFFIX%;%BASE%\javalib%SUFFIX%;%BASE%\scalalib%SUFFIX%
-  
+if "%SCALA_BIN_VER%" == "3" (
+  set NATIVELIB=%NATIVELIB% %BASE%\scala3lib%SUFFIX%
+)  
 scalac -classpath .;%NATIVELIB% -Xplugin:%PLUGIN% "%*"

--- a/cli/src/script/scala-native-ld
+++ b/cli/src/script/scala-native-ld
@@ -9,6 +9,11 @@ BASE="$(dirname $0)/.."
 CLILIB="$BASE/lib/scala-native-cli-assembly_$SCALA_BIN_VER-$SCALANATIVE_VER.jar"
 NATIVELIB=""
 libs="nativelib clib posixlib windowslib auxlib javalib scalalib"
+if [ "$SCALA_BIN_VER" = "3" ]; then
+    libs="$libs scala3lib"
+    NATIVELIB="$BASE/lib/scalalib_native${SCALANATIVE_BIN_VER}_2.13-$SCALANATIVE_VER.jar"
+fi
+
 for lib in $libs; do
     NATIVELIB="${NATIVELIB} $BASE/lib/${lib}_native${SCALANATIVE_BIN_VER}_$SCALA_BIN_VER-$SCALANATIVE_VER.jar"
 done

--- a/cli/src/script/scala-native-ld.bat
+++ b/cli/src/script/scala-native-ld.bat
@@ -11,5 +11,8 @@ set SUFFIX=_native%SCALANATIVE_BIN_VER%_%SCALA_BIN_VER%-%SCALANATIVE_VER%.jar
 set CLILIB=%BASE%\scala-native-cli-assembly_%SCALA_BIN_VER%-%SCALANATIVE_VER%.jar
 set PLUGIN=%BASE%\nscplugin_%SCALA_VER%-%SCALANATIVE_VER%.jar
 set NATIVELIB=%BASE%\nativelib%SUFFIX% %BASE%\clib%SUFFIX% %BASE%\posixlib%SUFFIX% %BASE%\windowslib%SUFFIX% %BASE%\auxlib%SUFFIX% %BASE%\javalib%SUFFIX% %BASE%\scalalib%SUFFIX%
+if "%SCALA_BIN_VER%" == "3" (
+  set NATIVELIB=%NATIVELIB% %BASE%\scala3lib%SUFFIX% %BASE%\scalalib_native%SCALANATIVE_BIN_VER%_2.13-%SCALANATIVE_VER%.jar
+)
 
 scala -classpath %CLILIB% scala.scalanative.cli.ScalaNativeLd  %* %NATIVELIB%

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-// SN plugin used only to get correct binary version of Scala Native
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.2")


### PR DESCRIPTION
* Use correct Scala binaries for Scala 3 in scripted tests 
* Update sbt to 1.6.1
* Add explicit maven repo resolvers for sbt 1.6.1
* Get rid of ScalaNative plugin dependency
* Update sh scripts for Scala 3