### PR TITLE
Send logging to stderr

### DIFF
--- a/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/ScalaNativeLd.scala
@@ -53,13 +53,13 @@ object ScalaNativeLd {
       case _: BuildTarget.Library  => false
     }
     if (needsMain && options.config.main.isEmpty) {
-      println("Required option not specified: --main")
+      System.err.println("Required option not specified: --main")
       sys.exit(1)
     } else {
       val (ignoredArgs, classpath) =
         options.classpath.partition(_.startsWith("-"))
       ignoredArgs.foreach { arg =>
-        println(s"Unrecognised argument: ${arg}")
+        System.err.println(s"Unrecognised argument: ${arg}")
       }
       val main = options.config.main
       val buildOptionsMaybe = ConfigConverter.convert(options, main, classpath)

--- a/cli/src/main/scala/scala/scalanative/cli/utils/FilteredLogger.scala
+++ b/cli/src/main/scala/scala/scalanative/cli/utils/FilteredLogger.scala
@@ -1,12 +1,22 @@
 package scala.scalanative.cli.utils
 
+import java.lang.System.err
+
 import scala.scalanative.build.Logger
 
 class FilteredLogger(
     private val verbosity: Int
 ) extends Logger {
 
-  private val underlying = Logger.default
+  private val underlying: Logger =
+    // Like Logger.default, but sending everything to stderr
+    new Logger {
+      def trace(msg: Throwable): Unit = err.println(s"[trace] $msg")
+      def debug(msg: String): Unit = err.println(s"[debug] $msg")
+      def info(msg: String): Unit = err.println(s"[info] $msg")
+      def warn(msg: String): Unit = err.println(s"[warn] $msg")
+      def error(msg: String): Unit = err.println(s"[error] $msg")
+    }
 
   override def trace(msg: Throwable): Unit = underlying.trace(msg)
   override def debug(msg: String): Unit =


### PR DESCRIPTION
As scala-native-cli may be launched as a sub-process by other tools, what it prints to stdout might pollute what the other tool is sending to stdout. Better send its log messages to stderr straightaway.